### PR TITLE
refactor/#44 user orm di 리팩토링 및 prisma.ts 생성

### DIFF
--- a/domain/repositories/IUserRepository.ts
+++ b/domain/repositories/IUserRepository.ts
@@ -1,6 +1,6 @@
 import { User } from "@prisma/client";
 
-export interface UserRepository {
+export interface IUserRepository {
   findById: (id: number) => Promise<User | null>;
   findByEmail: (email: string) => Promise<User | null>;
   verifyPassword: (user: User, password: string) => Promise<boolean>;

--- a/domain/repositories/index.ts
+++ b/domain/repositories/index.ts
@@ -1,1 +1,1 @@
-export * from "@/domain/repositories/user-repository";
+export * from "@/domain/repositories/IUserRepository";

--- a/infrastructure/repositories/PriUserRepository.ts
+++ b/infrastructure/repositories/PriUserRepository.ts
@@ -1,8 +1,8 @@
 import { PrismaClient, User } from "@prisma/client";
-import { UserRepository } from "@/domain/repositories";
+import { IUserRepository } from "@/domain/repositories";
 import bcrypt from "bcrypt";
 
-export class PrismaUserRepository implements UserRepository {
+export class PriUserRepository implements IUserRepository {
   // refactor : 핫 리로딩으로 인한 prismaClient 의 중복생성을 방지하기 위해 의존성 주입 방식으로 변경
   
   // private prisma: PrismaClient;

--- a/infrastructure/repositories/index.ts
+++ b/infrastructure/repositories/index.ts
@@ -1,1 +1,1 @@
-export * from "@/infrastructure/repositories/pr-user-repository";
+export * from "@/infrastructure/repositories/PriUserRepository";

--- a/infrastructure/repositories/pr-user-repository.ts
+++ b/infrastructure/repositories/pr-user-repository.ts
@@ -3,12 +3,16 @@ import { UserRepository } from "@/domain/repositories";
 import bcrypt from "bcrypt";
 
 export class PrismaUserRepository implements UserRepository {
-  private prisma: PrismaClient;
+  // refactor : 핫 리로딩으로 인한 prismaClient 의 중복생성을 방지하기 위해 의존성 주입 방식으로 변경
+  
+  // private prisma: PrismaClient;
 
-  constructor() {
-    this.prisma = new PrismaClient();
-  }
+  // constructor() {
+  //   this.prisma = new PrismaClient(); // 자체 인스턴스 생성 방식
+  // }
 
+  constructor(private readonly prisma: PrismaClient) {} // 의존성 주입 방식
+  
   async findById(id: number): Promise<User | null> {
     return await this.prisma.user.findUnique({
       where: {

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,6 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient };
+export const prisma = globalForPrisma.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#44 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- user 리포지토리 구현체가 자체적으로 prismaClient 객체 인스턴스를 생성하는 방식에서 외부로부터 주입받는 방식으로 리팩토링
- 모든 di 구조로 변경된 리포지토리 구현체들이 하나의 글로벌 prismaClient 인스턴스를 사용하도록 관리하는 prisma.ts 생성

```typescript
// 사용 예시
import { prisma } from '@/lib/prisma'; // import 순서 주의
import { PrismaUserRepository } from '@/infrastructure/repositories/pr-user-repository';

// 리포지토리 인스턴스 생성 시 prisma 클라이언트 주입
const userRepository = new PrismaUserRepository(prisma);
```

<br>

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/2090c801-6192-4ceb-b704-dfdf4283277b)

![image](https://github.com/user-attachments/assets/14fb0b97-9175-4b0d-b6ab-a99279f5613a)

<br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 사용 방법에 문제가 있거나 오탈자가 보이면 코멘트 부탁드립니다.