### PR TITLE
refactor/#55 endingState로 변경

### DIFF
--- a/domain/repositories/ICharacterRepository.ts
+++ b/domain/repositories/ICharacterRepository.ts
@@ -5,5 +5,6 @@ export interface ICharacterRepository {
     findByUserId: (userId: number) => Promise<Character | null>;
     addEndingCount: (id: number) => Promise<number>; 
     create: (userId: number) => Promise<Character>;
-    isCheckEnding: (id: number) => Promise<boolean | null>;
+    updateForSunday: () => Promise<void>;
+    updateForMonday: () => Promise<void>;
 }

--- a/infrastructure/repositories/PriCharacterRepository.ts
+++ b/infrastructure/repositories/PriCharacterRepository.ts
@@ -34,21 +34,44 @@ export class PriCharacterRepository implements ICharacterRepository {
   }
 
   async create(userId: number): Promise<Character> {
+    const today = new Date();
+    const dayOfWeek = today.getDay(); // 0: 일요일, 1: 월요일, ..., 6: 토요일
+
+    let endingState = 1;
+    if (dayOfWeek === 0) { // 일요일
+      endingState = 0;
+    }
+
     return await this.prisma.character.create({
       data: {
         userId,
         endingCount: 0,
-        isCheckEnding: false,
-      }
-    })
+        endingState,
+      },
+    });
   }
 
-  async isCheckEnding(id: number): Promise<boolean | null> {
-    const character = await this.findById(id);
-    if (!character) {
-      return false
-    }
-    return character.isCheckEnding;
+  // 일요일에 endingState가 1인 사용자들의 endingState를 2로 업데이트
+
+  async updateForSunday(): Promise<void> {
+    await this.prisma.character.updateMany({
+      where: {
+        endingState: 1,
+      },
+      data: {
+        endingState: 2,
+      },
+    });
+  }
+
+  // 월요일에 모든 사용자의 endingState를 1로 업데이트
+
+  async updateForMonday(): Promise<void> {
+    await this.prisma.character.updateMany({
+      data: {
+        endingState: 1,
+      },
+    });
   }
   
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#55 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- charater 스키마 변경에 따른 charater Repository 변경입니다.
- charater 생성 시 endingState를 추가했습니다.
- 일요일에 endingState가 1인 사용자들의 endingState를 2로 업데이트 되도록 구현했습니다.
- 월요일에 모든 사용자의 endingState를 1로 업데이트 되도록 구현했습니다.
- getDay (현재 요일을 숫자로 반환하는 메서드)를 사용하여 요일에 적용했습니다.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay


<br>
<img width="436" alt="스크린샷 2025-02-26 오후 9 33 49" src="https://github.com/user-attachments/assets/f7d5d33a-f894-49cf-b176-03adff8415e1" />

<img width="317" alt="스크린샷 2025-02-25 오후 4 36 26" src="https://github.com/user-attachments/assets/2e50650b-cbbd-485b-92d1-e19c03e9bcfb" />


<br>

## 💬리뷰 요구사항(선택)

현재는 new Date().getDay()를 사용해 코드 실행 시점의 요일을 확인하고 상태를 변경합니다
이 방식이 적절한지 검토가 필요합니다.
