### PR TITLE
refactor/#65 navigation 각 버튼 비활성화 기능 추가

### DIFF
--- a/components/common/Navigation.tsx
+++ b/components/common/Navigation.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { useRouter } from "next/navigation";
 import { Tabs, TabsList, TabsTrigger } from "@/components/common/tabs";
 import "@hackernoon/pixel-icon-library/fonts/iconfont.css";
-import menus from "@/constants/menu";
+import { MENUS } from "@/constants/menu";
 
 // <Navigation selectedMenu="선택된 메뉴명" />으로 사용
 
@@ -39,7 +39,7 @@ const Navigation = ({selectedMenu="character"}:{selectedMenu?:string}) => {
                 `
                 .replace(/\s+/g, ' ').trim()
                 }>
-                    {menus.slice(0, 2).map(({ menu, icon, label }) => (
+                    {MENUS.slice(0, 2).map(({ menu, icon, label, disabled }) => (
                     <TabsTrigger key={menu} className={`
                         is-rounded-navi
                         flex
@@ -52,7 +52,7 @@ const Navigation = ({selectedMenu="character"}:{selectedMenu?:string}) => {
                         ${selectedMenu === menu ? `pt-1 pb-0` : `pb-1`}
                     `
                     .replace(/\s+/g, ' ').trim()
-                    } value={menu}>
+                    } value={menu} disabled={disabled}>
                         <div className={`
                             icon
                             flex
@@ -98,9 +98,9 @@ const Navigation = ({selectedMenu="character"}:{selectedMenu?:string}) => {
                         max-[300px]:min-w-[70px]
                 `
                 .replace(/\s+/g, ' ').trim()}>
-                {menus[2] && (
+                {MENUS[2] && (
                 <TabsTrigger
-                    key={menus[2].menu}
+                    key={MENUS[2].menu}
                     className={`
                         is-rounded-full
                         flex
@@ -118,10 +118,10 @@ const Navigation = ({selectedMenu="character"}:{selectedMenu?:string}) => {
                             max-[300px]:h-[80px]
                         max-[430px]:pt-3
                         border-transparent
-                    ${selectedMenu === menus[2].menu ? "bg-white" : "transparent text-white"}
+                    ${selectedMenu === MENUS[2].menu ? "bg-white" : "transparent text-white"}
                     text-lg sm:text-base`
                     .replace(/\s+/g, ' ').trim()}
-                    value={menus[2].menu}
+                    value={MENUS[2].menu}
                 >
                     <div className={`
                         icon
@@ -133,9 +133,9 @@ const Navigation = ({selectedMenu="character"}:{selectedMenu?:string}) => {
                     `
                     .replace(/\s+/g, ' ').trim()
                     }>
-                        <i className={`hn ${selectedMenu === menus[2].menu ? `hn-${menus[2].icon}-solid` : `hn-${menus[2].icon}`} text-[26px] min-[430px]:text-[30px]`}></i>
+                        <i className={`hn ${selectedMenu === MENUS[2].menu ? `hn-${MENUS[2].icon}-solid` : `hn-${MENUS[2].icon}`} text-[26px] min-[430px]:text-[30px]`}></i>
                     </div>
-                    <span className="text-[16px] max-[430px]:text-[14px]">{menus[2].label}</span>
+                    <span className="text-[16px] max-[430px]:text-[14px]">{MENUS[2].label}</span>
                 </TabsTrigger>
                 )}
                 </div>
@@ -149,7 +149,7 @@ const Navigation = ({selectedMenu="character"}:{selectedMenu?:string}) => {
                 `
                 .replace(/\s+/g, ' ').trim()
                 }>
-                    {menus.slice(3, 5).map(({ menu, icon, label }) => (
+                    {MENUS.slice(3, 5).map(({ menu, icon, label, disabled }) => (
                     <TabsTrigger key={menu} className={`
                         is-rounded-navi
                         flex
@@ -162,7 +162,7 @@ const Navigation = ({selectedMenu="character"}:{selectedMenu?:string}) => {
                         ${selectedMenu === menu ? `pt-1 pb-0` : `pb-1`}
                     `
                     .replace(/\s+/g, ' ').trim()
-                    } value={menu}>
+                    } value={menu} disabled={disabled}>
                         <div className={`
                             icon
                             flex

--- a/constants/menu.ts
+++ b/constants/menu.ts
@@ -1,13 +1,18 @@
-// 줄바꿈 필요 시 배열로 지정
+// 줄바꿈 필요 시 배열로 지정 (2줄 이상 불가)
 // 예) label: ["칭호 도감"] → label: ["칭호", "도감"]
 
+type MenusDto = {
+  menu: string;
+  icon: string;
+  label: string | string[];
+  disabled?: boolean; // 특정 요소 비활성화 필요 시 disabled 속성 추가
+};
+
 // 메뉴 정보 배열 (5개로 고정 필수)
-const menus = [
+export const MENUS: MenusDto[] = [
     { menu: "character", icon: "user", label: "캐릭터" },
-    { menu: "cards", icon: "book-heart", label: ["버프", "카드"] },
+    { menu: "cards", icon: "book-heart", label: ["버프", "카드"], disabled: true }, 
     { menu: "quest", icon: "receipt", label: "퀘스트" }, // 중앙 버튼
     { menu: "titlebook", icon: "trophy", label: ["칭호", "도감"] },
-    { menu: "ending", icon: "octagon-check", label: "엔딩" },
+    { menu: "ending", icon: "octagon-check", label: "엔딩" }
 ];
-
-export default menus;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#65

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 메뉴 상수에 disabled 속성 추가
- disabled 속성이 배열 내에 없더라도 정상적으로 동작하도록 type 선언
- Navigation 공통 컴포넌트에 반영되도록 적용 (disabled 속성이 추가된 요소는 버튼 비활성화)

### 스크린샷 (선택)
![20250228-navigation_1](https://github.com/user-attachments/assets/aa493980-af02-470f-a9c7-05a400ae882c)
![20250228-navigation_2](https://github.com/user-attachments/assets/ed524710-e2a9-4e3f-b609-520cd88e092c)

<br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- 기타 수정사항이 있으면 피드백 부탁드립니다.
<br>
