### PR TITLE
feat/#71 ending 페이지 및 API 구현

### DIFF
--- a/app/api/ending/route.ts
+++ b/app/api/ending/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { EndingUsecase } from "@/application/usecases/ending/EndingUsecase";
+import {
+  PriTitleRepository,
+  PriUserTitleRepository,
+  PriCharacterRepository,
+  PriStatusRepository,
+} from "@/infrastructure/repositories";
+import { prisma } from "@/lib/prisma";
+
+// 엔딩 페이지 랜딩시 호출되는 API
+export async function GET(request: Request) {
+  try {
+    const userId = request.headers.get("X-User-Id"); // 수신 request headers
+
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const titleRepository = new PriTitleRepository(prisma);
+    const userTitleRepository = new PriUserTitleRepository(prisma);
+    const characterRepository = new PriCharacterRepository(prisma);
+    const statusRepository = new PriStatusRepository(prisma);
+
+    const endingUsecase = new EndingUsecase(
+      titleRepository,
+      userTitleRepository,
+      characterRepository,
+      statusRepository
+    );
+
+    const result = await endingUsecase.execute(Number(userId));
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Ending API Error:", error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -173,4 +173,11 @@ body {
     border-image-outset:4;
     border-radius: 0;
   }
+
+  .is-center {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    justify-content: center;
+  }
 }

--- a/app/play/ending/_components/EndingImage.tsx
+++ b/app/play/ending/_components/EndingImage.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import Image from "next/image";
+
+interface EndingImageProps {
+  image: string;
+}
+
+const EndingImage = ({ image }: EndingImageProps) => {
+  return (
+    <div className="relative w-full aspect-video">
+      <Image src={image} alt="엔딩 이미지" fill className="object-cover" />
+    </div>
+  );
+};
+
+export default EndingImage;

--- a/app/play/ending/_components/EndingScriptBox.tsx
+++ b/app/play/ending/_components/EndingScriptBox.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+interface EndingScriptBoxProps {
+  script: string;
+}
+
+const EndingScriptBox = ({ script }: EndingScriptBoxProps) => {
+  return (
+    <div className="is-rounded bg-white">
+      <p className="text-lg text-center max-w-md">{script}</p>
+    </div>
+  );
+};
+
+export default EndingScriptBox;

--- a/app/play/ending/_components/EndingScriptBox.tsx
+++ b/app/play/ending/_components/EndingScriptBox.tsx
@@ -6,8 +6,8 @@ interface EndingScriptBoxProps {
 
 const EndingScriptBox = ({ script }: EndingScriptBoxProps) => {
   return (
-    <div className="is-rounded bg-white">
-      <p className="text-lg text-center max-w-md">{script}</p>
+    <div className="is-rounded bg-white w-full">
+      <p className="text-lg text-center ">{script}</p>
     </div>
   );
 };

--- a/app/play/ending/_components/index.ts
+++ b/app/play/ending/_components/index.ts
@@ -1,0 +1,4 @@
+import EndingImage from "@/app/play/ending/_components/EndingImage";
+import EndingScriptBox from "@/app/play/ending/_components/EndingScriptBox";
+
+export { EndingImage, EndingScriptBox };

--- a/app/play/ending/page.tsx
+++ b/app/play/ending/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { EndingDTO } from "@/application/usecases/ending/dtos";
+import {
+  EndingState,
+  FADE_STEP_DURATION,
+  TOAST_DELAY,
+  TOTAL_FADE_DURATION,
+} from "@/constants";
+import Navigation from "@/components/common/Navigation";
+import { Toaster } from "@/components/common";
+import { toast } from "sonner";
+import { EndingImage, EndingScriptBox } from "@/app/play/ending/_components";
+
+const EndingPage = () => {
+  const [endingData, setEndingData] = useState<EndingDTO | null>(null);
+  const [fadeStep, setFadeStep] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchEndingData = async () => {
+      try {
+        const response = await fetch("/api/ending", {
+          headers: {
+            "X-User-Id": "1", // 추후 zustand 속 ID로 대체 필요
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error("엔딩 정보를 가져오는데 실패했습니다.");
+        }
+
+        const data = await response.json();
+        setEndingData(data);
+
+        // 단계적 페이드인 시작
+        const fadeInterval = setInterval(() => {
+          setFadeStep((prev) => {
+            if (prev >= 7) {
+              clearInterval(fadeInterval);
+              return 7;
+            }
+            return prev + 1;
+          });
+        }, FADE_STEP_DURATION);
+
+        // 토스트는 페이드인이 완료된 후 표시
+        setTimeout(() => {
+          toast("🏆 새로운 칭호를 획득했습니다!", {
+            duration: 3000,
+          });
+          setTimeout(() => {
+            toast(
+              <div className="flex flex-col gap-2">
+                <p className="text-lg font-bold">
+                  {data.achievableTitle.titleName}
+                </p>
+                <p className="text-sm text-gray-500">
+                  {data.achievableTitle.description}
+                </p>
+              </div>
+            );
+          }, 1000);
+        }, TOTAL_FADE_DURATION + TOAST_DELAY);
+
+        return () => clearInterval(fadeInterval);
+      } catch (error) {
+        setError(
+          error instanceof Error
+            ? error.message
+            : "알 수 없는 오류가 발생했습니다."
+        );
+        setFadeStep(7); // 에러 시 바로 표시
+      }
+    };
+
+    fetchEndingData();
+  }, []);
+
+  const getOverlayClass = () => {
+    switch (fadeStep) {
+      case 0:
+        return "opacity-100";
+      case 1:
+        return "opacity-90";
+      case 2:
+        return "opacity-75";
+      case 3:
+        return "opacity-60";
+      case 4:
+        return "opacity-45";
+      case 5:
+        return "opacity-30";
+      case 6:
+        return "opacity-15";
+      case 7:
+        return "opacity-0";
+      default:
+        return "opacity-100";
+    }
+  };
+
+  return (
+    <>
+      <Toaster />
+      <div className="relative min-h-screen bg-black py-3">
+        <div className="flex flex-col items-center justify-center min-h-screen space-y-8">
+          {error ? (
+            <div className="flex flex-col items-center justify-center min-h-screen">
+              <p className="text-red-500">{error}</p>
+            </div>
+          ) : !endingData ? (
+            <div className="flex flex-col items-center justify-center min-h-screen">
+              <p>로딩 중...</p>
+            </div>
+          ) : (
+            <>
+              <EndingImage image={endingData.endingImage} />
+
+              <EndingScriptBox script={endingData.endingPrompt} />
+
+              {/* 추후 삭제 */}
+              <div className="text-sm text-gray-500">
+                상태: {EndingState[endingData.endingState]}
+              </div>
+
+              <div
+                className={`absolute inset-0 bg-black transition-opacity duration-500 ease-[steps(1,end)] pointer-events-none ${getOverlayClass()}`}
+              />
+            </>
+          )}
+          <Navigation selectedMenu="ending" />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default EndingPage;

--- a/app/play/ending/page.tsx
+++ b/app/play/ending/page.tsx
@@ -3,13 +3,10 @@
 import { useEffect, useState } from "react";
 import { EndingDTO } from "@/application/usecases/ending/dtos";
 import {
-  EndingState,
   FADE_STEP_DURATION,
   TOAST_DELAY,
   TOTAL_FADE_DURATION,
 } from "@/constants";
-import Navigation from "@/components/common/Navigation";
-import { Toaster } from "@/components/common";
 import { toast } from "sonner";
 import { EndingImage, EndingScriptBox } from "@/app/play/ending/_components";
 
@@ -102,38 +99,27 @@ const EndingPage = () => {
   };
 
   return (
-    <>
-      <Toaster />
-      <div className="relative min-h-screen bg-black py-3">
-        <div className="flex flex-col items-center justify-center min-h-screen space-y-8">
-          {error ? (
-            <div className="flex flex-col items-center justify-center min-h-screen">
-              <p className="text-red-500">{error}</p>
-            </div>
-          ) : !endingData ? (
-            <div className="flex flex-col items-center justify-center min-h-screen">
-              <p>로딩 중...</p>
-            </div>
-          ) : (
-            <>
-              <EndingImage image={endingData.endingImage} />
-
-              <EndingScriptBox script={endingData.endingPrompt} />
-
-              {/* 추후 삭제 */}
-              <div className="text-sm text-gray-500">
-                상태: {EndingState[endingData.endingState]}
-              </div>
-
-              <div
-                className={`absolute inset-0 bg-black transition-opacity duration-500 ease-[steps(1,end)] pointer-events-none ${getOverlayClass()}`}
-              />
-            </>
-          )}
-          <Navigation selectedMenu="ending" />
-        </div>
+    <div className="relative min-h-screen bg-black">
+      <div className="is-center min-h-screen space-y-8">
+        {error ? (
+          <div className="is-center min-h-screen">
+            <p className="text-red-500">{error}</p>
+          </div>
+        ) : !endingData ? (
+          <div className="is-center min-h-screen">
+            <p>로딩 중...</p>
+          </div>
+        ) : (
+          <>
+            <EndingImage image={endingData.endingImage} />
+            <EndingScriptBox script={endingData.endingPrompt} />
+            <div
+              className={`absolute inset-0 bg-black pointer-events-none ${getOverlayClass()}`}
+            />
+          </>
+        )}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/constants/ending.ts
+++ b/constants/ending.ts
@@ -1,5 +1,6 @@
 // 엔딩 이미지 기본값
-export const DEFAULT_ENDING_IMAGE = "/images/endings/default.jpg";
+// export const DEFAULT_ENDING_IMAGE = "/endings/default.jpg";
+export const DEFAULT_ENDING_IMAGE = "/endings/cyberpunk-street-background4.png";
 
 // 엔딩 프롬프트 기본값
 export const DEFAULT_ENDING_PROMPT = "당신만의 특별한 여정이 새로운 이야기를 만들어냈습니다...";
@@ -19,3 +20,8 @@ export const ENDING_IMAGES: Record<number, string> = {
   3: "/endings/ending3.jpg",
   // add
 };
+
+// 페이드 시간
+export const FADE_STEP_DURATION = 500; // 각 페이드 단계 시간 (ms)
+export const TOTAL_FADE_DURATION = FADE_STEP_DURATION * 7; // 전체(7단계) 페이드 시간
+export const TOAST_DELAY = 500; // 페이드 완료 후 토스트 표시 대기 시간


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#71 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

![Mar-04-2025 15-50-55](https://github.com/user-attachments/assets/7d78bd76-cc14-4cdb-9bcc-f9e1878f36a9)

- 엔딩 페이지를 추가하였습니다.
- 엔딩 페이지에서 사용하는 하위 컴포넌트를 추가하였습니다.
- 엔딩 페이지에 대한 레트로한 페이드인 효과를 구성하였습니다.
- 페이드인에 대한 상수를 추가하였습니다.
- 엔딩 페이지 랜딩 시 요청을 위한 api router 를 추가하였습니다.
- 전역 is-center css class 를 추가하였습니다.
- x 축 margin 및 navigation, toaster 컴포넌트는 layout.ts 에 의존하도록 제거하였습니다.

- 공통으로 사용 가능한 에러 페이지, 로딩 페이지에 대한 상세 구현이 필요합니다.
- 추후 엔딩 페이지에 대한 배경 이미지가 상세 정의된 후 상수 영역에서 변경이 필요합니다.
- 엔딩 스크립트 출력에 대한 협의가 필요합니다.

<br>

### 스크린샷 (선택)

- 엔딩 페이지 랜딩 API
![image](https://github.com/user-attachments/assets/a1090d7e-2c01-43a6-8c2d-5aa66b8b31c2)

<br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 에러 및 잘못된 구현사항은 코멘트 부탁드립니다.