### PR TITLE
fix/#104 Navigation 컴포넌트 중앙 버튼 클릭시 하얀색 사각 배경 수정

### DIFF
--- a/components/common/Navigation.tsx
+++ b/components/common/Navigation.tsx
@@ -64,6 +64,7 @@ const Navigation: React.FC<NavigationProps> = ({ selectedMenu = "character", cla
               className={`is-rounded-full flex flex-col justify-center items-center absolute left-1/2 -translate-x-1/2 -translate-y-1/2
                 min-w-[100px] max-[430px]:min-w-[90px] max-[300px]:w-[80px]
                 h-[100px] max-[300px]:h-[80px] max-[430px]:pt-3 border-transparent
+                data-[state=active]:bg-transparent data-[state=active]:text-white
                 ${selectedMenu === MENUS[2].menu ? "bg-white" : "transparent text-white"} text-lg sm:text-base`}
               value={MENUS[2].menu}
             >


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#104

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- Navigation 컴포넌트에서 중앙부 버튼 클릭시 사각형으로 하얀색 배경이 나타나지 않도록 data-state가 active일 경우 background를 transparent가 되도록 지정했습니다.

<br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
