### PR TITLE
hotfix/#118 회원가입 시 인증메일 발송 후 이메일 주소 수정 구현

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -455,13 +455,11 @@ const SignUp = () => {
                     `
                     is-rounded-form
                     w-full
-                    ${isCodeSent && "text-muted-foreground"}
                     shadow-none
                   `}
                   type="email"
                   ref={emailRef}
-                  onChange={handleEmailChange}
-                  readOnly={isCodeSent} />
+                  onChange={handleEmailChange} />
                 <Button style={{padding: "4px 16px",marginRight: 0}} onClick={handleCheckExistEmail}>중복확인</Button>
             </div>
             {(emailEmpty


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#118

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 회원가입 시 이메일 중복확인 후 이메일을 통해 인증번호 발송 시 readonly 속성으로 이메일 주소를 수정 불가능하게 하여, 사용자 입장에서 불편감이 있던 것을 이메일 주소 수정 가능하도록 하여 해소

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
