### PR TITLE
fix/#124 칭호도감 이미지 표시불가 및 화면잘림 문제 수정

### DIFF
--- a/app/play/title/_components/renderTitleItem.tsx
+++ b/app/play/title/_components/renderTitleItem.tsx
@@ -10,7 +10,7 @@ const RenderTitleItem = ({ title, index }: TitleItemProps) => {
     const imageUrl = title.titleId ? `/titles/title_df.png` : `${title.img}`;
     
             return (
-                <div key={index} className="items-center justify-center text-center mb-10">
+                <div key={index} className="items-center justify-center text-center">
                     <Image src={imageUrl} alt="칭호이미지" width={100} height={100} />
                     <p>{title.name}</p>
                 </div>

--- a/app/play/title/_components/renderTitleItem.tsx
+++ b/app/play/title/_components/renderTitleItem.tsx
@@ -11,7 +11,7 @@ const RenderTitleItem = ({ title, index }: TitleItemProps) => {
     
             return (
                 <div key={index} className="items-center justify-center text-center">
-                    <Image src={imageUrl} alt="칭호이미지" width={100} height={100} />
+                    <Image className="mx-auto" src={imageUrl} alt="칭호이미지" width={100} height={100} />
                     <p>{title.name}</p>
                 </div>
             );

--- a/app/play/title/page.tsx
+++ b/app/play/title/page.tsx
@@ -37,7 +37,7 @@ export default function TitlePage(){
     const handleNextPage = () => {
         if (titles.length && titles.length % 9 === 0) {
             setPage(page + 1);
-        }    
+        }
     };
     
     useEffect(() => {
@@ -47,7 +47,7 @@ export default function TitlePage(){
     return (
         <div className="bg-slate-400 flex items-center justify-center p-5 flex-1">
             <div className="bg-white p-8 w-full overflow-hidden">
-                <h1 className="mb-20 text-2xl">칭호 도감</h1>
+                <h1 className="mb-10 text-2xl">칭호 도감</h1>
                 <div className="grid grid-cols-3 gap-5">
                     {gridItems.map((title, index) => (
                         <RenderTitleItem key={index} title={title} index={index} />

--- a/middleware.ts
+++ b/middleware.ts
@@ -86,5 +86,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!_next/|api/|endings/|fonts/|icons/|images/|js/|manifest.json).*)"], // _next, /api, /icons, /images 경로 제외, /mainfest.json 예외 처리
+  matcher: ["/((?!_next/|api/|endings/|titles/|fonts/|icons/|images/|js/|manifest.json).*)"], // _next, /api, /icons, /images 경로 제외, /mainfest.json 예외 처리
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#124

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 칭호도감 메뉴 페이지에서 이미지가 표시되지 않는 문제는 미들웨어의 matcher에 '/titles'를 기입하여 해당 경로 필터링.
- 칭호도감 페이지 내 요소 별 간격을 조정하여 페이지네이션 가려짐 문제 보완.

### 스크린샷 (선택)
![20250312-titles-view](https://github.com/user-attachments/assets/af2bc981-f9d2-4469-b82b-0ad66fbb2ba2)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
