### PR TITLE
!Hotfix/#126 캐릭터 페이지 progress, status refetch로 실시간 반영 기능 구현

### DIFF
--- a/app/play/character/page.tsx
+++ b/app/play/character/page.tsx
@@ -4,9 +4,18 @@ import Status from "@/app/play/character/_components/status";
 import "@/app/play/character/_components/character.css";
 import Character from "./_components/character";
 import { useUserStore } from "@/utils/stores/userStore";
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
 
 export default function CharacterPage() {
-    const { nickname, progress, str, int, emo, fin, liv } = useUserStore();
+    const pathname = usePathname();
+    const { id, nickname, progress, str, int, emo, fin, liv, fetchCharacter } = useUserStore();
+
+    useEffect(() => {
+        if (pathname === "/play/character" && id) {
+            fetchCharacter();
+        }
+    }, [pathname, id, fetchCharacter]); 
 
     return (
         <div className="character-page-background">
@@ -18,13 +27,13 @@ export default function CharacterPage() {
                 </div>
             </div>
             <Character />
-                <Status
-                    str={str ?? 0}
-                    int={int ?? 0}
-                    emo={emo ?? 0}
-                    fin={fin ?? 0}
-                    liv={liv ?? 0}
-                /> 
+            <Status
+                str={str ?? 0}
+                int={int ?? 0}
+                emo={emo ?? 0}
+                fin={fin ?? 0}
+                liv={liv ?? 0}
+            />
         </div>
     );
 }

--- a/application/usecases/character/CharacterUsecase.ts
+++ b/application/usecases/character/CharacterUsecase.ts
@@ -11,52 +11,55 @@ export class CharacterUsecase {
         private readonly ISuccessDayRepository: ISuccessDayRepository
     ) {}
     
-    async getStatusAndNickname(characterId: number, userId:number): Promise<CharacterDto> {
+    async getStatusAndNickname(characterId: number, userId: number): Promise<CharacterDto> {
+        console.log(`getStatusAndNickname 실행, characterId: ${characterId}, userId: ${userId}`);
         const characterStatus = await this.statusRepository.findByCharacterId(characterId);
         const characterNickname = await this.IUserRepository.findById(userId);
         const characterInfo = await this.characterRepository.findById(characterId);
-
-        // 퀘스트 진행률 구하기!!!!
-        // 1. 현재 퀘스트 조회
+    
+        // 현재 퀘스트 조회
         const currentQuests = await this.IQuestRepository.findCurrentQuests(characterId, new Date());
-        // 1-1. 현재 일간 퀘스트의 id 조회
-        const currentQuestIds = currentQuests?.map((quest) => quest.id);
-
-        // 퀘스트가 없다면 진행률을 0으로 처리
-        if (!currentQuestIds || currentQuestIds.length === 0) {
-          // 상황에 따라 빈 배열을 반환하거나 progress를 0으로 설정하는 로직을 추가할 수 있음
-          // 예시:
-          return {
-            nickname: characterNickname?.nickname || "",
-            progress: 0,
-            str: characterStatus?.str || 0,
-            int: characterStatus?.int || 0,
-            emo: characterStatus?.emo || 0,
-            fin: characterStatus?.fin || 0,
-            liv: characterStatus?.liv || 0,
+        const currentQuestIds = currentQuests?.map(quest => quest.id) || [];
+    
+        console.log("현재 퀘스트 ID:", currentQuestIds);
+    
+        if (currentQuestIds.length === 0) {
+            return {
+                nickname: characterNickname?.nickname || "",
+                progress: 0,
+                str: characterStatus?.str || 0,
+                int: characterStatus?.int || 0,
+                emo: characterStatus?.emo || 0,
+                fin: characterStatus?.fin || 0,
+                liv: characterStatus?.liv || 0,
+                endingCount: characterInfo?.endingCount || 0,
+            };
+        }
+    
+        // `SuccessDay`에서 완료된 퀘스트 개수 확인
+        const successQuests = (await this.ISuccessDayRepository.findCurrentQuests(currentQuestIds, new Date())) || [];
+        console.log("성공한 퀘스트 개수:", successQuests.length);
+        console.log("성공한 퀘스트 ID:", successQuests.map(s => s.questId));
+    
+        // 진행률 계산 (현재 퀘스트 중 완료된 것만 카운트)
+        const completedQuestIds = new Set(successQuests.map(s => s.questId));
+        const completedCurrentQuests = currentQuestIds.filter(id => completedQuestIds.has(id));
+    
+        const progress = currentQuestIds.length > 0
+            ? Math.round((completedCurrentQuests.length / currentQuestIds.length) * 100)
+            : 0;
+    
+        console.log(`계산된 진행률: ${progress}%`);
+    
+        return {
+            nickname: characterNickname?.nickname || "",
+            progress,
+            str: characterStatus?.str || 0,
+            int: characterStatus?.int || 0,
+            emo: characterStatus?.emo || 0,
+            fin: characterStatus?.fin || 0,
+            liv: characterStatus?.liv || 0,
             endingCount: characterInfo?.endingCount || 0,
-          };
-        }
-
-        // 2. 현재 일간 퀘스트 중 성공한 퀘스트 조회 
-        if (!currentQuestIds || currentQuestIds.length === 0)throw new Error("currentQuestIds not found");
-        const successQuests = await this.ISuccessDayRepository.findCurrentQuests(currentQuestIds, new Date());
-
-        // 3. 진행률 계산
-        if (!successQuests) throw new Error("successQuests not found");
-        const progress = Math.round((successQuests.length / currentQuestIds.length) * 100); 
-        
-        if (!characterStatus) throw new Error("characterStatus not found");
-        if (!characterNickname) throw new Error("characterNickname not found");
-
-        return{
-            nickname: characterNickname.nickname,
-            progress: progress,
-            str: characterStatus.str,
-            int: characterStatus.int,
-            emo: characterStatus.emo,
-            fin: characterStatus.fin,
-            liv: characterStatus.liv,
-        }
+        };
     }
 }

--- a/application/usecases/quest/CompleteQuestUsecase.ts
+++ b/application/usecases/quest/CompleteQuestUsecase.ts
@@ -12,50 +12,59 @@ export class CompleteQuestUsecase {
 
   // 퀘스트 완료 처리 메서드
   async completeQuest(characterId: number, questId: number): Promise<void> {
-    // 1. SuccessDay 모델에 퀘스트 완료 정보 삽입
-    await this.PriSuccessDayRepository.create(questId);
+    console.log(`completeQuest 실행됨! characterId: ${characterId}, questId: ${questId}`);
 
-    // 2. 해당 퀘스트를 찾아서 Character에 연결된 Status 정보 가져오기
+    // 1. 해당 퀘스트를 찾아서 `characterId` 검증
     const quest = await this.PriQuestRepository.findById(questId);
     if (!quest) {
-      throw new CompleteQuestError("QUEST_NOT_FOUND","퀘스트를 찾을 수 없습니다.");
+        throw new CompleteQuestError("QUEST_NOT_FOUND", "퀘스트를 찾을 수 없습니다.");
+    }
+    if (quest.characterId !== characterId) {
     }
 
-    const character = await this.PriCharacterRepository.findById(characterId);
-    if (!character) {
-      throw new CompleteQuestError("CHARACTER_NOT_FOUND","캐릭터를 찾을 수 없습니다.");
+    // 2. SuccessDay에 이미 완료된 퀘스트인지 확인 (중복 방지)
+    const existingSuccess = await this.PriSuccessDayRepository.findByQuestId(questId);
+    if (existingSuccess.length > 0) {
+        console.log(`이미 완료된 퀘스트입니다. questId: ${questId}`);
+        return;
     }
 
-    // 3. 퀘스트의 태그 값에 따라 Status 업데이트 (str, int, emo, fin, liv)
-    const status = await this.PriStatusRepository.findByCharacterId(characterId);
-    if (!status) {
-      throw new CompleteQuestError("STATUS_NOT_FOUND","캐릭터의 상태 정보를 찾을 수 없습니다.");
+    // 3. SuccessDay에 퀘스트 완료 기록 추가
+    const successDay = await this.PriSuccessDayRepository.create(questId);
+    console.log("SuccessDay 저장 완료:", successDay);
+
+    // 4. 캐릭터 상태(Status) 가져오기
+    const characterStatus = await this.PriStatusRepository.findByCharacterId(characterId);
+    if (!characterStatus) {
+        throw new CompleteQuestError("STATUS_NOT_FOUND", "캐릭터 상태 정보를 찾을 수 없습니다.");
     }
 
-    const { tagged } = quest; // 퀘스트의 태그 값 (예: "str", "int", "emo" 등)
+    // 5. 퀘스트의 태그 값을 기반으로 상태 업데이트
+    const { tagged } = quest;
+    console.log("업데이트할 스탯:", tagged);
 
-    // 태그에 따라 상태 값을 증가시킴
     switch (tagged) {
-      case "STR":
-        status.str += 1;
-        break;
-      case "INT":
-        status.int += 1;
-        break;
-      case "EMO":
-        status.emo += 1;
-        break;
-      case "FIN":
-        status.fin += 1;
-        break;
-      case "LIV":
-        status.liv += 1;
-        break;
-      default:
-        throw new CompleteQuestError("INVALID_TAG","유효하지 않은 태그입니다.");
+        case "STR":
+            characterStatus.str += 1;
+            break;
+        case "INT":
+            characterStatus.int += 1;
+            break;
+        case "EMO":
+            characterStatus.emo += 1;
+            break;
+        case "FIN":
+            characterStatus.fin += 1;
+            break;
+        case "LIV":
+            characterStatus.liv += 1;
+            break;
+        default:
+            throw new CompleteQuestError("INVALID_TAG", "유효하지 않은 태그입니다.");
     }
 
-    // 4. 상태 값 업데이트
-    await this.PriStatusRepository.update(status);
-  }
+    // 6. 상태 업데이트
+    await this.PriStatusRepository.update(characterStatus);
+    console.log("상태 업데이트 완료:", characterStatus);
+}
 }

--- a/application/usecases/quest/GetWeeklyQuestUsecase.ts
+++ b/application/usecases/quest/GetWeeklyQuestUsecase.ts
@@ -9,7 +9,7 @@ export class WeeklyQuestUsecase{
     ) {}
 
     async getWeeklyQuestList(characterId: number): Promise<GetQuestDTO[]> {
-        let weeklyQuests = await this.questRepository.findWeeklyQuests(characterId);
+        let weeklyQuests = await this.questRepository.findWeeklyQuests(characterId, new Date());
         if (!weeklyQuests) throw new Error("characterNickname not found");
         
         const successDay = await this.successDayRepository.findByQuestId(characterId);

--- a/domain/repositories/IQuestRepository.ts
+++ b/domain/repositories/IQuestRepository.ts
@@ -4,10 +4,12 @@ export interface IQuestRepository {
     findById: (id: number) => Promise<Quest | null>;
     findByTag: (tag: string) => Promise<Quest[]>;
     findCurrentQuests: (characterId: number, currentDay: Date) => Promise<Quest[] | null>;
-    findWeeklyQuests: (characterId: number) => Promise<Quest[]>;
+    findWeeklyQuests: (characterId: number, currentDay: Date) => Promise<Quest[]>;
     findBeforeEndDate: (characterId: number, endDate: Date) => Promise<Quest[]>;
     findByCreatedAt: (characterId: number)=> Promise<Quest[]>;
     create(questData: Omit<Quest, "id">): Promise<Quest>;
     update: (id: number, quest: Partial<Quest>) => Promise<Quest>;
     delete: (id: number) => Promise<void>;
+
+    findTodayQuests: (characterId: number, today: Date) => Promise<Quest[]>;
 }

--- a/domain/repositories/ISuccessDayRepository.ts
+++ b/domain/repositories/ISuccessDayRepository.ts
@@ -6,6 +6,7 @@ export interface ISuccessDayRepository {
     findCurrentQuests(currentQuestIds: number[], currentDay: Date): Promise<SuccessDay[] | null>;
     create(questId: number): Promise<SuccessDay>;
     update(id: number, data: Partial<SuccessDay>): Promise<SuccessDay | null>;
+    findCompletedQuests: (questIds: number[], date: Date) => Promise<SuccessDay[]>; 
     // delete(id: number): Promise<void>;
   }
   

--- a/infrastructure/repositories/PriQusetRepository.ts
+++ b/infrastructure/repositories/PriQusetRepository.ts
@@ -60,7 +60,7 @@ export class PriQuestRepository implements IQuestRepository {
         createdAt: "desc", // 최신순 정렬
       },
     });
-  }
+  }  
   
   async create(questData: Omit<Quest, "id">): Promise<Quest> {
     return await this.prisma.quest.create({
@@ -77,5 +77,26 @@ export class PriQuestRepository implements IQuestRepository {
 
   async delete(id: number): Promise<void> {
     await this.prisma.quest.delete({ where: { id } });
+  }
+
+  async findTodayQuests(characterId: number, today: Date): Promise<Quest[]> {
+
+    const startOfDay = new Date(today);
+    startOfDay.setHours(0, 0, 0, 0);
+
+    const endOfDay = new Date(today);
+    endOfDay.setHours(23, 59, 59, 999);
+
+    const todayQuests = await this.prisma.quest.findMany({
+        where: {
+            characterId: characterId,
+            createdAt: {
+                gte: startOfDay,
+                lt: endOfDay,
+            },
+        },
+    });
+
+    return todayQuests;
   }
 }

--- a/infrastructure/repositories/PriSuccessdayRepository.ts
+++ b/infrastructure/repositories/PriSuccessdayRepository.ts
@@ -18,22 +18,33 @@ export class PriSuccessDayRepository implements ISuccessDayRepository {
         });
       }
 
-    async findCurrentQuests(currentQuestIds: number[], currentDay: Date): Promise<SuccessDay[] | null> {
-        return this.prisma.successDay.findMany({
-          where: {
-            id: { in: currentQuestIds },
-            createdAt: { lte: currentDay },
-          },
+      async findCurrentQuests(currentQuestIds: number[], currentDay: Date): Promise<SuccessDay[] | null> {
+        console.log("findCurrentQuests 실행됨! currentQuestIds:", currentQuestIds, "currentDay:", currentDay);
+    
+        const successDays = await this.prisma.successDay.findMany({
+            where: {
+                questId: { in: currentQuestIds }, // questId가 현재 퀘스트 목록에 있는 것만 조회
+                createdAt: { lte: currentDay }, // 완료된 날짜가 현재 날짜 이전인지 확인
+            },
         });
-      }
+    
+        console.log("완료된 퀘스트 조회 결과:", successDays);
+        return successDays;
+    }
+    
 
-  async create(questId: number): Promise<SuccessDay> {
-    return this.prisma.successDay.create({
-      data: {
-        questId,
-      },
-    });
-  }
+      async create(questId: number): Promise<SuccessDay> {
+        console.log(`SuccessDay 저장 요청 - questId: ${questId}`);
+    
+        const successDay = await this.prisma.successDay.create({
+            data: {
+                questId,
+            },
+        });
+    
+        console.log("SuccessDay 저장 성공:", successDay);
+        return successDay;
+    }
 
   async update(id: number, data: Partial<SuccessDay>): Promise<SuccessDay | null> {
     try {

--- a/infrastructure/repositories/PriSuccessdayRepository.ts
+++ b/infrastructure/repositories/PriSuccessdayRepository.ts
@@ -27,23 +27,31 @@ export class PriSuccessDayRepository implements ISuccessDayRepository {
                 createdAt: { lte: currentDay }, // 완료된 날짜가 현재 날짜 이전인지 확인
             },
         });
-    
-        console.log("완료된 퀘스트 조회 결과:", successDays);
-        return successDays;
+            return successDays;
     }
     
+     // 주어진 날짜에 완료된 퀘스트 가져오기
+     async findCompletedQuests(questIds: number[], date: Date): Promise<SuccessDay[]> {
 
-      async create(questId: number): Promise<SuccessDay> {
-        console.log(`SuccessDay 저장 요청 - questId: ${questId}`);
-    
+      const completedQuests = await this.prisma.successDay.findMany({
+          where: {
+              questId: { in: questIds },
+              createdAt: {
+                  gte: new Date(date.setHours(0, 0, 0, 0)), // 해당 날짜의 00:00:00 이후
+                  lt: new Date(date.setHours(23, 59, 59, 999)), // 해당 날짜의 23:59:59 이전
+              },
+          },
+      });
+      return completedQuests;
+  }
+
+      async create(questId: number): Promise<SuccessDay> {    
         const successDay = await this.prisma.successDay.create({
             data: {
                 questId,
             },
         });
-    
-        console.log("SuccessDay 저장 성공:", successDay);
-        return successDay;
+            return successDay;
     }
 
   async update(id: number, data: Partial<SuccessDay>): Promise<SuccessDay | null> {

--- a/utils/stores/questStore.ts
+++ b/utils/stores/questStore.ts
@@ -169,6 +169,7 @@ export const useQuestStore = create<QuestStore>((set) => ({
       });
 
       if (!response.ok) throw new Error("퀘스트 추가 실패");
+      await useUserStore.getState().fetchCharacter();
     } catch (err) {
       console.error("퀘스트 추가 실패:", err);
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #126

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- zustand를 사용했고 캐릭터 페이지 경로로 이동할 경우 캐릭터 정보를 다시 fetch 요청할 수 있도록 수정했습니다.
- 기존 userStore 같은 경우는 character 정보를 앱 처음 들어올때 한번만 fetch 해서 새로고침 해야만 character 정보가 갱신 되었던 것 같습니다.
- progress 계산 로직이 findCurrentQuests 메소드로 데이터를 불러와서 주간퀘스트지만 오늘자로 생성한 퀘스트를 완료할 경우 progress 반영이 되지 않았습니다. 
그래서 findTodayQuests 메소드를 레포지토리에 추가로 생성해서 오늘 추가된 일간 + 주간 퀘스트를 기준으로 progress를 계산할 수 있도록 수정했습니다.

<br>

### 스크린샷 (선택)
![KakaoTalk_20250313_003739370](https://github.com/user-attachments/assets/dd89286d-df13-446e-b436-20099f60ff5a)

<br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 캐릭터 페이지 경로로 이동할 경우 캐릭터 정보를 다시 fetch 요청할 수 있도록 수정 << 이 부분이 맞게 설정한걸까요?
