### PR TITLE
Fix/#143 IOS전용 PWA 설치 유도 팝업

### DIFF
--- a/components/installPrompt/InstallPrompt.tsx
+++ b/components/installPrompt/InstallPrompt.tsx
@@ -12,6 +12,7 @@ interface BeforeInstallPromptEvent extends Event {
 
 export default function InstallPrompt() {
   const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [showiOSPrompt, setShowiOSPrompt] = useState(false);
 
   const installHandler = () => {
     if (deferredPrompt) {
@@ -29,9 +30,16 @@ export default function InstallPrompt() {
 
   const closeHandler = () => {
     setDeferredPrompt(null);
+    setShowiOSPrompt(false);
   };
 
   useEffect(() => {
+    const isIOS = /iPhone|iPad|iPod/.test(navigator.userAgent) && !('MSStream' in window);
+    if (isIOS) {
+      setShowiOSPrompt(true);
+      return;
+    }
+
     const handlebeforeInstallPrompt = (e: BeforeInstallPromptEvent) => {
       e.preventDefault();
       setDeferredPrompt(e);
@@ -45,21 +53,38 @@ export default function InstallPrompt() {
   }, []);
 
   return (
-    deferredPrompt && (
-      <div className="is-rounded p-2 m-3 fixed bg-white z-10 left-0 right-0">
-        <div className="flex justify-center space-x-2">
-          <Image src={"/icons/32.png"} alt="설치 유도 아이콘"  width={50} height={50} className="mr-5" />
-          <p>홈 화면에 추가하여 <br />앱처럼 사용해보세요!</p>
+    <>
+      {deferredPrompt && (
+        <div className="is-rounded p-2 m-3 fixed bg-white z-10 left-0 right-0">
+          <div className="flex justify-center space-x-2">
+            <Image src={"/icons/32.png"} alt="설치 유도 아이콘" width={50} height={50} className="mr-5" />
+            <p>홈 화면에 추가하여 <br />앱처럼 사용해보세요!</p>
+          </div>
+          <div className="flex justify-center space-x-2">
+            <Button size="M" state={"success"} onClick={installHandler}>
+              홈 화면에 추가
+            </Button>
+            <Button size="XS" onClick={closeHandler}>
+              닫기
+            </Button>
+          </div>
         </div>
-        <div className="flex justify-center space-x-2">
-          <Button size="M" state={"success"} onClick={installHandler}>
-            홈 화면에 추가
-          </Button>
-          <Button size="XS" onClick={closeHandler}>
-            닫기
-          </Button>
+      )}
+
+      {showiOSPrompt && (
+        <div className="is-rounded p-2 m-3 fixed bg-white z-10 left-0 right-0">
+          <div className="flex justify-center space-x-2">
+            <Image src={"/icons/32.png"} alt="설치 유도 아이콘" width={50} height={50} className="mr-5" />
+            <p>Safari에서 <strong>공유</strong> 버튼을 누른 후 <br /> 
+            &quot;홈 화면에 추가&quot;를 선택하세요!</p>
+          </div>
+          <div className="flex justify-center space-x-2">
+            <Button size="XS" onClick={closeHandler}>
+              닫기
+            </Button>
+          </div>
         </div>
-      </div>
-    )
+      )}
+    </>
   );
 }

--- a/components/installPrompt/InstallPrompt.tsx
+++ b/components/installPrompt/InstallPrompt.tsx
@@ -75,7 +75,7 @@ export default function InstallPrompt() {
         <div className="is-rounded p-2 m-3 fixed bg-white z-10 left-0 right-0">
           <div className="flex justify-center space-x-2">
             <Image src={"/icons/32.png"} alt="설치 유도 아이콘" width={50} height={50} className="mr-5" />
-            <p>Safari에서 <strong>공유</strong> 버튼을 누른 후 <br /> 
+            <p><i className="hn hn-external-link-solid"></i> 공유버튼을 누른 후 <br /> 
             &quot;홈 화면에 추가&quot;를 선택하세요!</p>
           </div>
           <div className="flex justify-center space-x-2">


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#143 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 안드로이드 유저는 PWA 설치 유도 팝업이 정상적으로 작동합니다. 
- ios 유저는 PWA 설치 유도 팝업이 작동하지 않습니다.  PWA 설치 유도 팝업을 따로 구현했습니다.


<br>

### 스크린샷 (선택)
<img width="500" alt="420727169-28a52848-c279-4e7a-b38c-67264bc1e6d2" src="https://github.com/user-attachments/assets/1db8d399-79ef-477e-afe8-e0268b3518a9" />

<br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
