### PR TITLE
fix/#145 로그인 API에 zustand userStore의 fetchUser 호출 추가

### DIFF
--- a/app/(auth)/signin/page.tsx
+++ b/app/(auth)/signin/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button, Input } from "@/components/common";
+import { useUserStore } from "@/utils/stores/userStore";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -9,6 +10,7 @@ const SignIn = () => {
   const router = useRouter();
   const [loginId, setLoginId] = useState("");
   const [password, setPassword] = useState("");
+  const { fetchUser } = useUserStore(); // zustand에서 fetchUser 가져오기
 
   const handleSignIn = async () => {
     try {
@@ -18,11 +20,11 @@ const SignIn = () => {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ loginId, password }),
+        credentials: "include", // 쿠키 포함
       });
-
-      const data = await response.json();
-      console.log(data);
       if (response.ok) {
+        // 로그인 성공 시 fetchUser 호출
+        await fetchUser();
         router.push("/play/character"); // 인게임으로 이동
       }
     } catch (error) {

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -2,13 +2,15 @@
 
 import { LoginError } from "@/application/usecases/auth/errors/LoginError";
 import { Button, Input } from "@/components/common";
+import { useUserStore } from "@/utils/stores/userStore";
 import { useRouter } from "next/navigation";
 import { useRef, useState } from "react";
 
 const SignUp = () => {
   // React Router 호출
   const router = useRouter();
-
+  // Zustand에서 fetchUser 가져오기
+  const { fetchUser } = useUserStore();
 
   /* 로그인 ID 중복확인 시작 */
   const loginIdRef = useRef<HTMLInputElement>(null);
@@ -347,6 +349,7 @@ const SignUp = () => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ loginId, email, nickname, password }),
+        credentials: "include", // 쿠키 포함
       });
       if (!response.ok) {
         throw new Error("Network response was not ok");
@@ -358,6 +361,9 @@ const SignUp = () => {
     }
 
     alert("가입이 완료되었습니다!");
+
+    // 회원가입 성공 시 fetchUser 호출 후 리디렉션
+    await fetchUser();
 
     // // 가입 성공 시 로그인 페이지로 이동
     // router.push("/signin");

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -44,7 +44,7 @@ export async function POST(req: NextRequest) {
             httpOnly: true, // XSS 방지
             secure: process.env.NODE_ENV === "production", // 프로덕션에서만 Secure 적용
             path: "/", // 모든 경로에서 사용 가능
-            // maxAge: parseInt(process.env.ACCESS_TOKEN_EXPIRES || "3600", 10), // 유효기간 (초 단위)
+            maxAge: parseInt(process.env.ACCESS_TOKEN_EXPIRES || "3600", 10), // 유효기간 (초 단위)
         });
         response.cookies.set("refreshToken", refreshToken, {
             httpOnly: true,

--- a/app/play/character/page.tsx
+++ b/app/play/character/page.tsx
@@ -4,21 +4,12 @@ import Status from "@/app/play/character/_components/status";
 import "@/app/play/character/_components/character.css";
 import Character from "./_components/character";
 import { useUserStore } from "@/utils/stores/userStore";
-import { useEffect } from "react";
-import { usePathname } from "next/navigation";
 import { Button } from "@/components/common";
 import { useRouter } from "next/navigation";
 
 export default function CharacterPage() {
     const router = useRouter(); // Next Route 호출
-    const pathname = usePathname();
-    const { id, nickname, progress, str, int, emo, fin, liv, fetchCharacter } = useUserStore();
-
-    useEffect(() => {
-        if (pathname === "/play/character" && id) {
-            fetchCharacter();
-        }
-    }, [pathname, id, fetchCharacter]);
+    const { nickname, progress, str, int, emo, fin, liv } = useUserStore();
 
     const handleLogout = async () => {
         try {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#145

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 로그인 후 user-session-data가 앱 실행 시 생성되고 그 때 한번 fetchUser(유저 데이터 가져오는 메서드)되는 로직으로 구성되어, 유저 정보가 저장되지 않은 userStore를 useUserStore를 통해 불러오는 문제
  - [로그인 페이지] 로그인 처리 메서드에서 userStore의 fetchData 호출하여 user-session-data에 업데이트
  - [회원가입 페이지] 회원가입 시에도 로그인 후 인게임 페이지에 진입하기 때문에, 회원가입 처리 메서드에서 리다이렉트 전에 fetchData 호출

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 로직이 적절해보이는지 확인 부탁드립니다.
<br>
