### PR TITLE
Fix/#168 pwa logic

### DIFF
--- a/components/installPrompt/InstallPrompt.tsx
+++ b/components/installPrompt/InstallPrompt.tsx
@@ -29,7 +29,16 @@ export default function InstallPrompt() {
     }
   };
 
+  // 5분 후에 다시 뜨게
   const closeHandler = () => {
+    const nextShow = Date.now() + 5 * 60 * 1000; // 5분 후 타임스탬프
+    localStorage.setItem("pwaPromptNextShow", nextShow.toString());
+    setDeferredPrompt(null);
+    setShowIOSPrompt(false);
+  };
+
+  // 영구히 거절
+  const neverShowHandler = () => {
     localStorage.setItem("pwaPromptDismissed", "true");
     setDeferredPrompt(null);
     setShowIOSPrompt(false);
@@ -37,8 +46,10 @@ export default function InstallPrompt() {
 
   useEffect(() => {
     const isPromptDismissed = localStorage.getItem("pwaPromptDismissed") === "true";
-
     if (isPromptDismissed) return;
+
+    const nextShow = localStorage.getItem("pwaPromptNextShow");
+    if (nextShow && Date.now() < Number(nextShow)) return;
 
     // iOS 디바이스에서 PWA 설치 프롬프트를 표시하지 않도록 처리
     const isIOS = /iPhone|iPad|iPod/.test(navigator.userAgent) && !('MSStream' in window);
@@ -51,11 +62,11 @@ export default function InstallPrompt() {
       e.preventDefault();
       setDeferredPrompt(e);
     };
-    // PWA 설치 프롬프트 이벤트 리스너 등록
-    window.addEventListener("beforeInstallPrompt", handleBeforeInstallPrompt as EventListener);
+
+    window.addEventListener("beforeinstallprompt", handleBeforeInstallPrompt as EventListener);
 
     return () => {
-      window.removeEventListener("beforeInstallPrompt", handleBeforeInstallPrompt as EventListener);
+      window.removeEventListener("beforeinstallprompt", handleBeforeInstallPrompt as EventListener);
     };
   }, []);
 
@@ -74,6 +85,9 @@ export default function InstallPrompt() {
             <Button size="XS" onClick={closeHandler}>
               닫기
             </Button>
+            <Button size="XS" onClick={neverShowHandler}>
+              다시는 표시하지 않음
+            </Button>
           </div>
         </div>
       )}
@@ -86,9 +100,13 @@ export default function InstallPrompt() {
             &quot;홈 화면에 추가&quot;를 선택하세요!</p>
           </div>
           <div className="flex justify-center space-x-2">
+            <Button size="M" onClick={neverShowHandler}>
+              다시는 표시하지 않음
+            </Button>
             <Button size="XS" onClick={closeHandler}>
               닫기
             </Button>
+            
           </div>
         </div>
       )}

--- a/components/installPrompt/InstallPrompt.tsx
+++ b/components/installPrompt/InstallPrompt.tsx
@@ -12,7 +12,7 @@ interface BeforeInstallPromptEvent extends Event {
 
 export default function InstallPrompt() {
   const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
-  const [showiOSPrompt, setShowiOSPrompt] = useState(false);
+  const [showIOSPrompt, setShowIOSPrompt] = useState(false);
 
   const installHandler = () => {
     if (deferredPrompt) {
@@ -30,25 +30,25 @@ export default function InstallPrompt() {
 
   const closeHandler = () => {
     setDeferredPrompt(null);
-    setShowiOSPrompt(false);
+    setShowIOSPrompt(false);
   };
 
   useEffect(() => {
     const isIOS = /iPhone|iPad|iPod/.test(navigator.userAgent) && !('MSStream' in window);
     if (isIOS) {
-      setShowiOSPrompt(true);
+      setShowIOSPrompt(true);
       return;
     }
 
-    const handlebeforeInstallPrompt = (e: BeforeInstallPromptEvent) => {
+    const handleBeforeInstallPrompt = (e: BeforeInstallPromptEvent) => {
       e.preventDefault();
       setDeferredPrompt(e);
     };
 
-    window.addEventListener("beforeinstallprompt", handlebeforeInstallPrompt as EventListener);
+    window.addEventListener("beforeInstallPrompt", handleBeforeInstallPrompt as EventListener);
 
     return () => {
-      window.removeEventListener("beforeinstallprompt", handlebeforeInstallPrompt as EventListener);
+      window.removeEventListener("beforeInstallPrompt", handleBeforeInstallPrompt as EventListener);
     };
   }, []);
 
@@ -71,7 +71,7 @@ export default function InstallPrompt() {
         </div>
       )}
 
-      {showiOSPrompt && (
+      {showIOSPrompt && (
         <div className="is-rounded p-2 m-3 fixed bg-white z-10 left-0 right-0">
           <div className="flex justify-center space-x-2">
             <Image src={"/icons/32.png"} alt="설치 유도 아이콘" width={50} height={50} className="mr-5" />

--- a/components/installPrompt/InstallPrompt.tsx
+++ b/components/installPrompt/InstallPrompt.tsx
@@ -23,28 +23,35 @@ export default function InstallPrompt() {
         } else {
           console.log("User dismissed the install prompt");
         }
+        localStorage.setItem("pwaPromptDismissed", "true");
         setDeferredPrompt(null);
       });
     }
   };
 
   const closeHandler = () => {
+    localStorage.setItem("pwaPromptDismissed", "true");
     setDeferredPrompt(null);
     setShowIOSPrompt(false);
   };
 
   useEffect(() => {
+    const isPromptDismissed = localStorage.getItem("pwaPromptDismissed") === "true";
+
+    if (isPromptDismissed) return;
+
+    // iOS 디바이스에서 PWA 설치 프롬프트를 표시하지 않도록 처리
     const isIOS = /iPhone|iPad|iPod/.test(navigator.userAgent) && !('MSStream' in window);
     if (isIOS) {
       setShowIOSPrompt(true);
       return;
     }
-
+    // IOS 제외한 브라우저에서만 PWA 설치 프롬프트를 처리
     const handleBeforeInstallPrompt = (e: BeforeInstallPromptEvent) => {
       e.preventDefault();
       setDeferredPrompt(e);
     };
-
+    // PWA 설치 프롬프트 이벤트 리스너 등록
     window.addEventListener("beforeInstallPrompt", handleBeforeInstallPrompt as EventListener);
 
     return () => {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#168 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 1. localStorage를 이용해 PWA 설치 유도 프롬프트 단 한 번만 노출되도록 처리
- 이후 페이지를 새로고침하거나 재방문해도 프롬프트가 다시 나타나지 않도록 설정
- iOS 프롬프트(setShowIOSPrompt) 역시 같은 방식으로 제어하여 중복 노출 방지

- '다시는 표시하지 않음' 버튼을 누르면, 로컬스토리지에 저장되어 해당 프롬프트가 영구적으로 표시되지 않도록 처리했습니다.
- 기존의 '닫기' 버튼은 프롬프트를 일시적으로 숨기되, 5분 후에 다시 표시되도록 변경했습니다.

 : 새로고침 및 페이지를 변환해도 설치 프롬프트가 뜨지 않습니다.


<br>

### 스크린샷 (선택)
### 수정 전    ->     수정 후 
![befor-ezgif com-optimize](https://github.com/user-attachments/assets/67fcbd1a-6deb-4c1a-9b0f-109b7dd0cadc)![after-ezgif com-optimize](https://github.com/user-attachments/assets/ef7ea57f-6c6e-4a4f-a4cb-28c1e7fec381)

### '다시는 표시하지 않음' 버튼 추가
<img width="250" alt="스크린샷 2025-05-22 오후 3 30 39" src="https://github.com/user-attachments/assets/5c05094e-5127-4114-99fa-e5e4e2df780d" />


<br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
